### PR TITLE
Fixed mistake parsing charge description & statute.

### DIFF
--- a/Counties/Florida/Bay County/Scraper/Scraper.py
+++ b/Counties/Florida/Bay County/Scraper/Scraper.py
@@ -225,20 +225,15 @@ def scrape_record(case_number):
 
     Charges = {}
     for charge in charges_table:
-        charge_details = charge.find_elements_by_tag_name('td')
-        count = int(charge_details[0].text.strip())
-        long_desc = charge_details[1].text.strip()
-        # Statute is contained within brackets
-        if '(' in long_desc and ')' in long_desc:
-            statute = long_desc[long_desc.find('(') + 1:long_desc.find(')')]
-        else:
-            statute = None
-        description = long_desc.split('(')[0]
-        level = charge_details[2].text.strip()
-        degree = charge_details[3].text.strip()
-        # plea = charge_details[4].text.strip() # Plea is not filled out on this portal.
-        disposition = charge_details[5].text.strip()
-        disposition_date = charge_details[6].text.strip()
+        charge_cols = charge.find_elements_by_tag_name('td')
+        count = int(charge_cols[0].text.strip())
+        charge_desc = charge_cols[1].text
+        description, statute = ScraperUtils.parse_charge_statute(charge_desc)
+        level = charge_cols[2].text.strip()
+        degree = charge_cols[3].text.strip()
+        # plea = charge_cols[4].text.strip() # Plea is not filled out on this portal.
+        disposition = charge_cols[5].text.strip()
+        disposition_date = charge_cols[6].text.strip()
         offense_date = None  # Not shown on this portal
         citation_number = None  # Not shown on this portal
         Charges[count] = Charge(count, statute, description, level, degree, disposition, disposition_date, offense_date,
@@ -290,10 +285,7 @@ def scrape_record(case_number):
         MiddleName = None
         LastName = None
         if ',' in full_name:
-            name_split = full_name.split(',')[1].lstrip().split()
-            FirstName = name_split[0]
-            MiddleName = " ".join(name_split[1:])
-            LastName = full_name.split(',')[0]
+            FirstName, MiddleName, LastName = ScraperUtils.parse_name(full_name)
         else:
             # If there's no comma, it's a corporation name.
             FirstName = full_name

--- a/Counties/Florida/Bay County/Scraper/tests/test_ScraperUtils.py
+++ b/Counties/Florida/Bay County/Scraper/tests/test_ScraperUtils.py
@@ -7,6 +7,7 @@ class TestScraperUtils:
 
     def test_parse_plea_case_numbers_blank(self):
         assert ScraperUtils.parse_plea_case_numbers("", [1, 2, 3]) == []
+        assert ScraperUtils.parse_plea_case_numbers(None, [1, 2, 3]) == []
 
     def test_parse_plea_case_numbers__no_charge_mentioned(self):
         plea = "PLEA OF NOT GUILTY"
@@ -15,6 +16,7 @@ class TestScraperUtils:
     def test_parse_plea_case_numbers_one_charge_mentioned(self):
         plea = "DEFENDANT ENTERED PLEA OF : NOLO-CONTENDERE SEQ 2"
         assert ScraperUtils.parse_plea_case_numbers(plea, [1, 2]) == [2]
+        assert ScraperUtils.parse_plea_case_numbers(plea, None) == []
 
     def test_parse_plea_case_numbers_no_charge_numbers(self):
         plea = "DEFENDANT ENTERED PLEA OF NOLO CONTENDERE SEQ: 1,2,3,4,5"
@@ -31,6 +33,7 @@ class TestScraperUtils:
 
     def test_parse_plea_type_blank(self):
         assert ScraperUtils.parse_plea_type('') is None
+        assert ScraperUtils.parse_plea_type(None) is None
 
     def test_parse_plea_type_nolo_contendere(self):
         plea1 = 'PLEA OF NOLO CONTENDERE'
@@ -54,6 +57,38 @@ class TestScraperUtils:
         assert ScraperUtils.parse_plea_type(plea2) == 'Not Guilty'
         assert ScraperUtils.parse_plea_type(plea3) == 'Not Guilty'
 
+    def test_parse_name(self):
+        name1 = "DOE, JANE EMILY"
+        name2 = "DOE, JOHN"
+        assert ScraperUtils.parse_name(name1) == ('JANE', 'EMILY', 'DOE')
+        assert ScraperUtils.parse_name(name2) == ('JOHN', None, 'DOE')
+
+    def test_parse_name_error(self):
+        name1 = None
+        name2 = ''
+        assert ScraperUtils.parse_name(name1) == (None, None, None)
+        assert ScraperUtils.parse_name(name2) == (None, None, None)
+
+    def test_parse_charge_statute(self):
+        charge1 = '	FLEEING OR ATTEMPTING TO ELUDE (HIGH SPEED RECKLESS) (3161935 3)  '
+        charge2 = 'DRIVING WHILE LICENSE SUSPENDED OR REVOKED (32234 2a)'
+        charge3 = '	FELON IN POSSESSION OF AMMUNITION (ACTUAL POSSESSION) (79023)  '
+        charge4 = None
+        assert ScraperUtils.parse_charge_statute(charge1) == (
+            'FLEEING OR ATTEMPTING TO ELUDE (HIGH SPEED RECKLESS)', '3161935 3')
+        assert ScraperUtils.parse_charge_statute(charge2) == ('DRIVING WHILE LICENSE SUSPENDED OR REVOKED', '32234 2a')
+        assert ScraperUtils.parse_charge_statute(charge3) == (
+            'FELON IN POSSESSION OF AMMUNITION (ACTUAL POSSESSION)', '79023')
+        assert ScraperUtils.parse_charge_statute(charge4) == (None, None)
+
+    def test_parse_charge_statute_incomplete(self):
+        charge1 = '(32234 2a)'
+        charge2 = 'DRIVING WHILE LICENSE SUSPENDED OR REVOKED'
+        charge3 = ' '
+        assert ScraperUtils.parse_charge_statute(charge1) == (None, '32234 2a')
+        assert ScraperUtils.parse_charge_statute(charge2) == (charge2, None)
+        assert ScraperUtils.parse_charge_statute(charge3) == (None, None)
+
     def test_parse_defense_attorneys(self):
         attorneys1 = ['DEFENSE ATTORNEY: DOE, JANE EMILY ASSIGNED', 'DEFENSE ATTORNEY: DOE, JOHN MICHAEL ASSIGNED', 'DEFENSE ATTORNEY: SELF, SELF ASSIGNED']
         public_defenders1 = ['COURT APPOINTED ATTORNEY: DOE, JOHN MICHAEL ASSIGNED']
@@ -63,8 +98,10 @@ class TestScraperUtils:
     def test_parse_defense_attorneys_invalid(self):
         invalid_test = ['', '', '']
         invalid_test2 = []
+        invalid_test3 = None
         assert ScraperUtils.parse_attorneys(invalid_test) is None
         assert ScraperUtils.parse_attorneys(invalid_test2) is None
+        assert ScraperUtils.parse_attorneys(invalid_test3) is None
 
     def test_parse_out_path_illegal_characters(self):
         filename_invalid_chars = 't<>:e"/s\\t|?n*ame'
@@ -73,8 +110,13 @@ class TestScraperUtils:
     def test_parse_out_path_valid(self):
         # Function should not affect valid length filenames and paths.
         normal_filename = 'document'
-        parsedPath = ScraperUtils.parse_out_path('C:\\Example\Path', normal_filename, 'pdf')
-        assert parsedPath == os.path.join('C:\\Example\Path', '{}.{}'.format(normal_filename, 'pdf'))
+        parsed_path = ScraperUtils.parse_out_path(r'C:\\Example\Path', normal_filename, 'pdf')
+        assert parsed_path == os.path.join(r'C:\\Example\Path', '{}.{}'.format(normal_filename, 'pdf'))
+
+    def test_filename_invalid(self):
+        filename = None
+        parsed_path = ScraperUtils.parse_out_path(r'C:\\Example\Path', filename, 'pdf')
+        assert parsed_path == os.path.join(r'C:\\Example\Path', '.pdf')
 
     def test_parse_out_path_filename_extension_shortening(self):
         # 252 characters long, but with the .pdf extension it becomes 256 characters long - one too many.


### PR DESCRIPTION
This PR fixes a mistake separating the charge description and statute from the full charge string in the case there were twos sets of brackets.

For instance, when parsing the text: `FELON IN POSSESSION OF AMMUNITION (ACTUAL POSSESSION) (79023)`


Before this would be parsed as:
`description=='FELON IN POSSESSION OF AMMUNITION'`,
`statute=='ACTUAL POSSESSION'`

Now this is correctly parsed as:
`description=='FELON IN POSSESSION OF AMMUNITION (ACTUAL POSSESSION)'`,
`statute==' 79023'`

* It also separates the parsing names into a function to allow for unit testing. 

* New tests for added test coverage.

* Solves some deprecation warnings about the use of escape characters.