### PR TITLE
ETL - UUID Fix and Schema.json Info

### DIFF
--- a/common/etl/pdap_dolt.py
+++ b/common/etl/pdap_dolt.py
@@ -15,7 +15,7 @@ import json
 import sys
 import uuid
 
-# TURN OFF FOR PROD
+# TURN OFF ONCE data_types-sandbox IS MERGED INTO MASTER
 dev_mode = True
 
 dolthub_org = 'pdap'
@@ -206,7 +206,7 @@ def new_dataset(dolt, agency, url):
         'notes': notes
     }])
     print("   [*] Inserting data to datasets table...")
-    id = uuid.uuid4()
+    id = str(uuid.uuid4()).replace('-','') # UUID without dashes
     insert = dolt.sql("INSERT into datasets (`id`, `url`, `name`, `aggregation_level`, `source_type_id`, `data_types_id`, `format_types_id`, `state_iso`, `county_fips`, `city_id`, `consolidator`, `portal_type`, `coverage_start`, `scraper_path`, `notes`) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}');".format(id, url, name, aggregation_level, source_type_id, data_types_id, format_types_id, state, fips, city_id, consolidator, portal, start, scraper_path, notes), result_format="csv")
     # and grab the record
     data = read_pandas_sql(dolt, "select * from datasets where id = '{}'".format(id))
@@ -229,8 +229,8 @@ def load_data(dolt, dataset_record, file):
 
     # load the file into a dataframe
     df = pd.read_csv(file)
-    # generate new UUID v4 IDs for each record, and push the column to the front
-    df = pd.concat([pd.Series([uuid.uuid4() for _ in range(len(df.index))], index=df.index, name='id'), df], axis=1)
+    # generate new UUID v4 IDs (with no dashes) for each record, and push the column to the front
+    df = pd.concat([pd.Series([str(uuid.uuid4()).replace('-','') for _ in range(len(df.index))], index=df.index, name='id'), df], axis=1)
     # set the index to our new ID column
     df.set_index('id')
     # add the datasets_fk

--- a/template/schema.json
+++ b/template/schema.json
@@ -1,8 +1,18 @@
 {
-    "data_type": "",
-    "full_data_location":"",
+    "dataset_id": "",
+    "dataset_info":{
+        "agency_name":"",
+        "agency_coords":{"lat": "", "long":""},
+        "url":"",
+        "aggregation":"",
+        "state": "",
+        "county":""
+    },
+    "data_type": 1,
+    "format_type": 1,
+    "source_type": 2,
+    "full_data_location":"/data",
     "mapping":[
 
-    ],
-    "_notes_":"This is a WIP for the ETL scripts. This file will be used to take the output of the scrapers, and format it correctly to be ingested by our ETL script. Final Format TBD"
+    ]
 }

--- a/template/schema.json
+++ b/template/schema.json
@@ -1,15 +1,16 @@
 {
-    "dataset_id": "",
-    "dataset_info":{
+    "agency_id": "",
+    "agency_info":{
         "agency_name":"",
         "agency_coords":{"lat": "", "long":""},
-        "url":"",
-        "aggregation":"",
         "state": "",
         "county":""
     },
     "data": [
         {
+            "dataset_id": "",
+            "url":"",
+            "aggregation":"",
             "full_data_location":"/data",
             "source_type": 2,
             "data_type": 1,

--- a/template/schema.json
+++ b/template/schema.json
@@ -8,11 +8,15 @@
         "state": "",
         "county":""
     },
-    "data_type": 1,
-    "format_type": 1,
-    "source_type": 2,
-    "full_data_location":"/data",
-    "mapping":[
-
+    "data": [
+        {
+            "full_data_location":"/data",
+            "source_type": 2,
+            "data_type": 1,
+            "format_type": 1,
+            "mapping":[
+            ]
+        }
     ]
+    
 }

--- a/template/schema_json_README.md
+++ b/template/schema_json_README.md
@@ -13,11 +13,12 @@ This guide shows you how to fill out the schema.json for use:
     * **`state`**: two-letter state code ('IN', 'CA')
     * **`county`**: county name in Title case (first letter capitalized: 'Marion', 'Bristol Bay') (leave blank if a state agency)
     * **`city`**: city of the agency (leave blank if a county or state agency)
-* **source_type**: use one of the values in the `id` column found in the source_types table [here] (https://www.dolthub.com/repositories/pdap/datasets/data/master/source_types)
-* **data_type**: use one of the values in the `id` column found in the data_types table [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/data_types) (such as `10` for `incident_reports` data)
-* **format_type**: use one of the values in the `id` column found in the format_types table [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/format_types) (such as `2` for `cityprotect` data)
-* **full_data_location**: the location of all the data from the scraper. It will most likely just be in the `/data` directory in the same folder after the scraper has ran
-* **mapping**: based off of your `data_type`, the data will be stored in a different table with different columns. This section is how your data maps to the columns in the database such as for `"table_col": "data_col"`
+* **data**: There can be multiple types of data from each agency, so this is an enumerable way to point to the different types of data stored. Store each type in a different directory such as `/incident_reports` , `/booking_reports` .etc. 
+    * **source_type**: use one of the values in the `id` column found in the source_types table [here] (https://www.dolthub.com/repositories/pdap/datasets/data/master/source_types)
+    * **data_type**: use one of the values in the `id` column found in the data_types table [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/data_types) (such as `10` for `incident_reports` data)
+    * **format_type**: use one of the values in the `id` column found in the format_types table [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/format_types) (such as `2` for `cityprotect` data)
+    * **full_data_location**: the location of all the data from the scraper. It will most likely just be in the `/data` directory in the same folder after the scraper has ran
+    * **mapping**: based off of your `data_type`, the data will be stored in a different table with different columns. This section is how your data maps to the columns in the database such as for `"table_col": "data_col"`
 
 
 ## Example

--- a/template/schema_json_README.md
+++ b/template/schema_json_README.md
@@ -21,6 +21,8 @@ This guide shows you how to fill out the schema.json for use:
 
 
 ## Example
+In this example, we only have one set of data from Clanton Police Department, Incident Reports. 
+If we end up getting more data form this agency (such as arrest records or booking reports), then we would put it in a *separate* directory such as `/booking_data` and add the information in the `data` dictionary of the new folder and it's contents
 
 ```
 {
@@ -33,14 +35,18 @@ This guide shows you how to fill out the schema.json for use:
         "state": "AL",
         "county":"Chilton"
     },
-    "source_type": 3,
-    "data_type": 10,
-    "format_type": 2,
-    "full_data_location":"/data",
-    "mapping":[
-        "ccn":"ccn",
-        "incidentDate": "date",
-        ...
+    "data": [
+        {
+            "full_data_location":"/data",
+            "source_type": 3,
+            "data_type": 10,
+            "format_type": 2,
+            "mapping":[
+                "ccn":"ccn",
+                "incidentDate": "date",
+                ...
+            ]
+        }
     ]
 }
 ```

--- a/template/schema_json_README.md
+++ b/template/schema_json_README.md
@@ -1,0 +1,47 @@
+Schema.json Guide
+===
+
+The `schema.json` is an overview of the data scraped, the dataset itself, and the table it will import to. It will be utilized in an automated ETL process.
+
+This guide shows you how to fill out the schema.json for use:
+* **dataset_id**: The ID from our list of datasets found [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/datasets). If this is a new dataset not yet in our table, leave this blank and the ETL script will use the data below to add a record and automatically add the ID to the schema.json file.
+* **dataset_information**: This provides more information about the dataset. If the ID is listed above and you change any information here, it will be automatically updated if the script is ran again.
+    * **`agency_name`**: name of the agency such as 'Gaston County Sheriff'
+    * **`agency_coords`**: this will probably require you to search up on Google Maps. This is actually very important to ensure we pull the correct FIPS and municipal codes. Search the agency on google maps, and right click on the pin to grab the lat and long coordinates. It is okay if there are multiple districts, just grab the main district if so.
+    * **`url`**: the url of the dataset used
+    * **`aggregation`**: this is how the data is aggregated. use `federal`, `state`, `county`, `muncipal` or `university`
+    * **`state`**: two-letter state code ('IN', 'CA')
+    * **`county`**: county name in Title case (first letter capitalized: 'Marion', 'Bristol Bay') (leave blank if a state agency)
+    * **`city`**: city of the agency (leave blank if a county or state agency)
+* **source_type**: use one of the values in the `id` column found in the source_types table [here] (https://www.dolthub.com/repositories/pdap/datasets/data/master/source_types)
+* **data_type**: use one of the values in the `id` column found in the data_types table [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/data_types) (such as `10` for `incident_reports` data)
+* **format_type**: use one of the values in the `id` column found in the format_types table [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/format_types) (such as `2` for `cityprotect` data)
+* **full_data_location**: the location of all the data from the scraper. It will most likely just be in the `/data` directory in the same folder after the scraper has ran
+* **mapping**: based off of your `data_type`, the data will be stored in a different table with different columns. This section is how your data maps to the columns in the database such as for `"table_col": "data_col"`
+
+
+## Example
+
+```
+{
+    "dataset_id": "5740697099a311ebab258c8590d4a7fc",
+    "dataset_info":{
+        "agency_name":"Clanton Police Department",
+        "agency_coords":{"lat": "32.83853", "long":"-86.62936"},
+        "url":"https://cityprotect.com/agency/540048e6ee664a6f88ae0ceb93717e50",
+        "aggregation":"municipal",
+        "state": "AL",
+        "county":"Chilton"
+    },
+    "source_type": 3,
+    "data_type": 10,
+    "format_type": 2,
+    "full_data_location":"/data",
+    "mapping":[
+        "ccn":"ccn",
+        "incidentDate": "date",
+        ...
+    ]
+}
+```
+

--- a/template/schema_json_README.md
+++ b/template/schema_json_README.md
@@ -4,17 +4,19 @@ Schema.json Guide
 The `schema.json` is an overview of the data scraped, the dataset itself, and the table it will import to. It will be utilized in an automated ETL process.
 
 This guide shows you how to fill out the schema.json for use:
-* **dataset_id**: The ID from our list of datasets found [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/datasets). If this is a new dataset not yet in our table, leave this blank and the ETL script will use the data below to add a record and automatically add the ID to the schema.json file.
-* **dataset_information**: This provides more information about the dataset. If the ID is listed above and you change any information here, it will be automatically updated if the script is ran again.
+
+* **agency_id**: id of the agency in the agencies table (leave)
+* **agency_info**: This provides more information about the dataset. If the ID is listed above and you change any information here, it will be automatically updated in the database if the script is ran again.
     * **`agency_name`**: name of the agency such as 'Gaston County Sheriff'
     * **`agency_coords`**: this will probably require you to search up on Google Maps. This is actually very important to ensure we pull the correct FIPS and municipal codes. Search the agency on google maps, and right click on the pin to grab the lat and long coordinates. It is okay if there are multiple districts, just grab the main district if so.
-    * **`url`**: the url of the dataset used
-    * **`aggregation`**: this is how the data is aggregated. use `federal`, `state`, `county`, `muncipal` or `university`
     * **`state`**: two-letter state code ('IN', 'CA')
     * **`county`**: county name in Title case (first letter capitalized: 'Marion', 'Bristol Bay') (leave blank if a state agency)
     * **`city`**: city of the agency (leave blank if a county or state agency)
 * **data**: There can be multiple types of data from each agency, so this is an enumerable way to point to the different types of data stored. Store each type in a different directory such as `/incident_reports` , `/booking_reports` .etc. 
-    * **source_type**: use one of the values in the `id` column found in the source_types table [here] (https://www.dolthub.com/repositories/pdap/datasets/data/master/source_types)
+    **dataset_id**: The ID from our list of datasets found [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/datasets). If this is a new dataset not yet in our table, leave this blank and the ETL script will use the information in `dataset_information` to add a record and automatically add the ID to the schema.json file.
+    * **`url`**: the url of the dataset used
+    * **`aggregation`**: this is how the data is aggregated. use `federal`, `state`, `county`, `muncipal` or `university`
+    * **source_type**: use one of the values in the `id` column found in the source_types table [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/source_types)
     * **data_type**: use one of the values in the `id` column found in the data_types table [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/data_types) (such as `10` for `incident_reports` data)
     * **format_type**: use one of the values in the `id` column found in the format_types table [here](https://www.dolthub.com/repositories/pdap/datasets/data/master/format_types) (such as `2` for `cityprotect` data)
     * **full_data_location**: the location of all the data from the scraper. It will most likely just be in the `/data` directory in the same folder after the scraper has ran
@@ -25,19 +27,20 @@ This guide shows you how to fill out the schema.json for use:
 In this example, we only have one set of data from Clanton Police Department, Incident Reports. 
 If we end up getting more data form this agency (such as arrest records or booking reports), then we would put it in a *separate* directory such as `/booking_data` and add the information in the `data` dictionary of the new folder and it's contents
 
-```
+```json
 {
-    "dataset_id": "5740697099a311ebab258c8590d4a7fc",
-    "dataset_info":{
+    "agency_id": "",
+    "agency_info":{
         "agency_name":"Clanton Police Department",
         "agency_coords":{"lat": "32.83853", "long":"-86.62936"},
-        "url":"https://cityprotect.com/agency/540048e6ee664a6f88ae0ceb93717e50",
-        "aggregation":"municipal",
         "state": "AL",
         "county":"Chilton"
     },
     "data": [
         {
+            "dataset_id": "5740697099a311ebab258c8590d4a7fc",
+            "url":"https://cityprotect.com/agency/540048e6ee664a6f88ae0ceb93717e50",
+            "aggregation":"municipal",
             "full_data_location":"/data",
             "source_type": 3,
             "data_type": 10,


### PR DESCRIPTION
- Changed references in `pdap_dolt` to ensure UUIDs are generated without the hyphens to match the database schema
- Added more columns to `schema.json` in the template folder
- Added guide on how to fill out `schema.json` in the template folder. This file will be a key file in keeping the information about the dataset up to date as well as how to correctly map the raw_data generated from the scraper into the the appropriate table.