### PR TITLE
Muckrock tools

### DIFF
--- a/muckrock-tools/README.md
+++ b/muckrock-tools/README.md
@@ -1,0 +1,28 @@
+# Muckrock Toolkit
+
+## Description
+This repo provides tools for searching Muckrock FOIA requests, it includes scripts for downloading data from MuckRock, generating CSV files per PDAP database requirements, and automatic labeling
+
+## Uses
+
+### 1. Simple Search Term
+- `muck-get.py`
+- script to perform searches on MuckRock's database, by matching a search string to title of request. Search is slow due to rate limiting (cannot multi thread around it).
+
+### 2. Clone Muckrock database & search locally
+- `download-muckrock-foia.py` `search-local-foia-json.py`
+- scripts to clone the MuckRock repository for fast local querying (total size <2GB at present)
+
+### 3. County Level Search
+- `get-allegheny-foias.py`, `allegheny-county-towns.txt`
+- To search for any and all requests in a certain county (e.g. Allegheny in this case) you must provide a list of all municipalities contained within the county. Muckrock stores geographic info in tiers, from Federal, State, and local level. At the local level, e.g. Pittsburgh and Allegheny County are in the same tier, with no way to determine which municipalities reside within a county (without providing it yourself).
+
+The `get-allegheny-foias.py` script will find the jurisdiction ID for each municipality in `allegheny-county-towns.txt`, then find all completed FOIA requests for those jurisdictions.
+
+### 4. Generate detailed FOIA data in PDAP database format 
+- `generate-detailed-muckrock-csv.py`
+- Once you have a json of relevant FOIA's, run it through this script to generate a CSV that fulfills PDAP database requirements.
+
+### 5. ML Labeling 
+- `muckrock-ml-labeler.py`
+- A tool for auto labeling MuckRock sources. This script is using [fine-url-classifier](https://huggingface.co/PDAP/fine-url-classifier) to assign 1 of 36 record type labels. At present, script is expecting each source to have associated header tags, provided via `html-tag-collector/collector.py`. (TODO: For muckrock sources, `collector.py` insufficient, does not grab main text of the request)  

--- a/muckrock-tools/allegheny-county-towns.txt
+++ b/muckrock-tools/allegheny-county-towns.txt
@@ -1,0 +1,61 @@
+Allegheny County
+Allison Park
+Bairdford
+Bakerstown
+Bethel Park
+Brackenridge
+Braddock
+Bradfordwoods
+Bridgeville
+Buena Vista
+Bunola
+Carnegie
+Cheswick
+Clairton
+Coraopolis
+Coulters
+Creighton
+Crescent
+Cuddy
+Curtisville
+Dravosburg
+Duquesne
+East McKeesport
+East Pittsburgh
+Elizabeth
+Gibsonia
+Glassport
+Glenshaw
+Greenock
+Harwick
+Homestead
+Imperial
+Indianola
+Ingomar
+Leetsdale
+McKees Rocks
+Mckeesport
+Monroeville
+Morgan
+Natrona Heights
+North Versailles
+Oakdale
+Oakmont
+Pitcairn
+Pittsburgh
+Presto
+Rural Ridge
+Russellton
+Sewickley
+South Park
+Springdale
+Sturgeon
+Tarentum
+Turtle Creek
+Verona
+Warrendale
+West Elizabeth
+West Mifflin
+Wexford
+Wildwood
+Wilmerding

--- a/muckrock-tools/download-muckrock-foia.py
+++ b/muckrock-tools/download-muckrock-foia.py
@@ -1,0 +1,43 @@
+import requests
+import csv
+import time
+import json
+
+# Define the base API endpoint
+base_url = "https://www.muckrock.com/api_v1/foia/"
+
+# Set initial parameters
+page = 1
+per_page = 100
+all_data = []
+output_file = "foia_data.json"
+
+# Function to fetch data from a specific page
+def fetch_page(page):
+    response = requests.get(base_url, params={"page": page, "page_size": per_page, "format": "json"})
+    if response.status_code == 200:
+        return response.json()
+    else:
+        print(f"Error fetching page {page}: {response.status_code}")
+        return None
+
+# Fetch and store data from all pages
+while True:
+    print(f"Fetching page {page}...")
+    data = fetch_page(page)
+    if data is None:
+        print(f"Skipping page {page}...")
+        page += 1
+        continue
+
+    all_data.extend(data['results'])
+    if not data['next']:
+        break
+
+    page += 1
+
+# Write data to CSV
+with open(output_file, mode='w', encoding='utf-8') as json_file:
+    json.dump(all_data, json_file, indent=4)
+
+print(f"Data written to {output_file}")

--- a/muckrock-tools/generate-detailed-muckrock-csv.py
+++ b/muckrock-tools/generate-detailed-muckrock-csv.py
@@ -1,0 +1,145 @@
+import json
+import argparse
+import csv
+import requests
+import time
+
+# Load the JSON data
+parser = argparse.ArgumentParser(description="Parse JSON from a file.")
+parser.add_argument('--json_file', type=str, required=True, help="Path to the JSON file")
+
+args = parser.parse_args()
+
+with open(args.json_file, 'r') as f:
+    json_data = json.load(f)
+
+# Define the CSV headers
+headers = [
+    "name", "agency_described", "record_type", "description", "source_url",
+    "readme_url", "scraper_url", "state", "county", "municipality",
+    "agency_type", "jurisdiction_type", "View Archive", "agency_aggregation",
+    "agency_supplied", "supplying_entity", "agency_originated", "originating_agency",
+    "coverage_start", "source_last_updated", "coverage_end", "number_of_records_available",
+    "size", "access_type", "data_portal_type", "access_notes", "record_format", "update_frequency",
+    "update_method", "retention_schedule", "detail_level"
+]
+
+def get_agency(agency_id):
+    # API call to get agency_described
+    if agency_id:
+        agency_url = f"https://www.muckrock.com/api_v1/agency/{agency_id}/"
+        response = requests.get(agency_url)
+    
+        if response.status_code == 200:
+            agency_data = response.json()
+            return agency_data
+        else:
+            return ""
+    else:
+        print("Agency ID not found in item")
+
+def get_jurisdiction(jurisdiction_id):
+    if jurisdiction_id:
+        jurisdiction_url = f"https://www.muckrock.com/api_v1/jurisdiction/{jurisdiction_id}/"
+        response = requests.get(jurisdiction_url)
+
+        if response.status_code == 200:
+            jurisdiction_data = response.json()
+            return jurisdiction_data
+        else:
+            return ""
+    else:
+        print("Jurisdiction ID not found in item")
+    
+
+# Open a CSV file for writing
+with open('detailed-muckrock-data.csv', 'w', newline='') as csvfile:
+    writer = csv.DictWriter(csvfile, fieldnames=headers)
+
+    # Write the header row
+    writer.writeheader()
+
+    # Iterate through the JSON data
+    for item in data:
+        print(f"Writing data for {item.get('title')}")
+        agency_data = get_agency(item.get("agency"))
+        time.sleep(1)
+        jurisdiction_data = get_jurisdiction(agency_data.get("jurisdiction"))
+
+        jurisdiction_level = jurisdiction_data.get("level")
+        #federal jurisduction level
+        if jurisdiction_level == "f":
+            state = ""
+            county = ""
+            municipality = ""
+            juris_type = "federal"
+        #state jurisdiction level
+        if jurisdiction_level == "s":
+            state = jurisdiction_data.get("name")
+            county = ""
+            municipality = ""
+            juris_type = "state"
+        #local jurisdiction level
+        if jurisdiction_level == "l":
+            parent_juris_data = get_jurisdiction(jurisdiction_data.get("parent"))
+            state = parent_juris_data.get("abbrev")
+            if "County" in jurisdiction_data.get("name"):
+                county = jurisdiction_data.get("name")
+                municipality = ""
+                juris_type = "county"
+            else:
+                county = ""
+                municipality = jurisdiction_data.get("name")
+                juris_type = "local"
+
+        if 'Police' in agency_data.get("types"):
+            agency_type = 'law enforcement/police'
+        else:
+            agency_type = ''
+
+        source_url = ''
+        absolute_url = item.get("absolute_url")
+        access_type = ''
+        for comm in item["communications"]:
+            if comm["files"]:
+                source_url = absolute_url + '#files'
+                access_type = 'Web page,Download,API'
+                break
+
+        # Extract the relevant fields from the JSON object
+        csv_row = {
+            "name": item.get("title", ""),
+            "agency_described": agency_data.get("name", "") + ' - ' + state,
+            "record_type": "",
+            "description": "",
+            "source_url": source_url,
+            "readme_url": absolute_url,
+            "scraper_url": "",
+            "state": state,
+            "county": county,
+            "municipality": municipality,
+            "agency_type": agency_type,
+            "jurisdiction_type": juris_type,
+            "View Archive": "",
+            "agency_aggregation": "",
+            "agency_supplied": "no",
+            "supplying_entity": "MuckRock",
+            "agency_originated": "yes",
+            "originating_agency": agency_data.get("name", ""),
+            "coverage_start": "",
+            "source_last_updated": "",
+            "coverage_end": "",
+            "number_of_records_available": "",
+            "size": "",
+            "access_type": access_type,
+            "data_portal_type": "MuckRock",
+            "access_notes": "",
+            "record_format": "",
+            "update_frequency": "",
+            "update_method": "",
+            "retention_schedule": "",
+            "detail_level": ""
+        }
+        
+        # Write the extracted row to the CSV file
+        writer.writerow(csv_row)

--- a/muckrock-tools/get-allegheny-foias.py
+++ b/muckrock-tools/get-allegheny-foias.py
@@ -1,0 +1,74 @@
+import requests
+import json
+import time
+
+# Function to fetch jurisdiction IDs based on town names from a text file
+def fetch_jurisdiction_ids(town_file, base_url):
+    with open(town_file, "r") as file:
+        town_names = [line.strip() for line in file]
+
+    jurisdiction_ids = {}
+    url = base_url
+
+    while url:
+        response = requests.get(url)
+        if response.status_code == 200:
+            data = response.json()
+            for item in data.get('results', []):
+                if item['name'] in town_names:
+                    jurisdiction_ids[item['name']] = item['id']
+
+            url = data.get("next")
+            print(f"Processed page, found {len(jurisdiction_ids)}/{len(town_names)} jurisdictions so far...")
+            time.sleep(1)  # To respect the rate limit
+
+        elif response.status_code == 503:
+            print("Error 503: Skipping page")
+            break
+        else:
+            print(f"Error fetching data: {response.status_code}")
+            break
+
+    return jurisdiction_ids
+
+# Function to fetch FOIA data for each jurisdiction ID and save it to a JSON file
+def fetch_foia_data(jurisdiction_ids):
+    all_data = []
+    for name, id_ in jurisdiction_ids.items():
+        url = f"https://www.muckrock.com/api_v1/foia/?status=done&jurisdiction={id_}"
+        while url:
+            response = requests.get(url)
+            if response.status_code == 200:
+                data = response.json()
+                all_data.extend(data.get("results", []))
+                url = data.get("next")
+                print(f"Fetching records for {name}, {len(all_data)} total records so far...")
+                time.sleep(1)  # To respect the rate limit
+            elif response.status_code == 503:
+                print(f"Error 503: Skipping page for {name}")
+                break
+            else:
+                print(f"Error fetching data: {response.status_code} for {name}")
+                break
+
+    # Save the combined data to a JSON file
+    with open("foia_data_combined.json", "w") as json_file:
+        json.dump(all_data, json_file, indent=4)
+
+    print(f"Saved {len(all_data)} records to foia_data_combined.json")
+
+# Main function to execute the script
+def main():
+    town_file = "allegheny-county-towns.txt"
+    jurisdiction_url = "https://www.muckrock.com/api_v1/jurisdiction/?level=l&parent=126"
+
+    # Fetch jurisdiction IDs based on town names
+    jurisdiction_ids = fetch_jurisdiction_ids(town_file, jurisdiction_url)
+    print(f"Jurisdiction IDs fetched: {jurisdiction_ids}")
+
+    # Fetch FOIA data for each jurisdiction ID
+    fetch_foia_data(jurisdiction_ids)
+
+# Run the main function
+if __name__ == "__main__":
+    main()

--- a/muckrock-tools/muck-get.py
+++ b/muckrock-tools/muck-get.py
@@ -1,0 +1,49 @@
+import requests
+
+# Define the base API endpoint
+base_url = "https://www.muckrock.com/api_v1/foia/"
+
+# Define the search string
+search_string = "use of force"
+per_page = 100
+page = 1
+all_results = []
+max_count = 20
+
+while True:
+
+    # Make the GET request with the search string as a query parameter
+    response = requests.get(base_url, params={"page" : page, "page_size" : per_page, "format": "json"})
+
+    # Check if the request was successful
+    if response.status_code == 200:
+        # Parse the JSON response
+        data = response.json()
+        
+        if not data['results']:
+            break
+
+        filtered_results = [item for item in data['results'] if search_string.lower() in item['title'].lower()]
+
+        all_results.extend(filtered_results)
+
+        if len(filtered_results) > 0:
+            num_results = len(filtered_results)
+            print(f"found {num_results} more matching result(s)...")
+
+        if len(all_results) >= max_count:
+            print("max count reached... exiting")
+            break
+
+        page += 1
+        
+    else:
+        print(f"Error: {response.status_code}")
+        break
+
+# Dump list into a JSON file
+json_out_file = search_string.replace(" ", "_") + ".json"
+with open(json_out_file, 'w') as json_file:
+    json.dump(all_results, json_file)
+
+print(f"List dumped into {json_out_file}")

--- a/muckrock-tools/muckrock-ml-labeler.py
+++ b/muckrock-tools/muckrock-ml-labeler.py
@@ -1,0 +1,41 @@
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+import torch
+import pandas as pd
+import argparse
+
+# Load the tokenizer and model
+model_name = "PDAP/fine-url-classifier"
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+model = AutoModelForSequenceClassification.from_pretrained(model_name)
+model.eval()
+
+# Load the dataset from command line argument
+parser = argparse.ArgumentParser(description="Load CSV file into a pandas DataFrame.")
+parser.add_argument('--csv_file', type=str, required=True, help="Path to the CSV file")
+args = parser.parse_args()
+df = pd.read_csv(args.csv_file)
+
+# Combine multiple columns (e.g., 'url', 'html_title', 'h1') into a single text field for each row
+columns_to_combine = ['url_path', 'html_title', 'h1']  # Add other columns here as needed
+df['combined_text'] = df[columns_to_combine].apply(lambda row: ' '.join(row.values.astype(str)), axis=1)
+
+# Convert the combined text into a list
+texts = df['combined_text'].tolist()
+
+# Tokenize the inputs
+inputs = tokenizer(texts, padding=True, truncation=True, return_tensors="pt")
+
+# Perform inference
+with torch.no_grad():
+    outputs = model(**inputs)
+
+# Get the predicted labels
+predictions = torch.argmax(outputs.logits, dim=-1)
+
+# Map predictions to labels
+labels = model.config.id2label
+predicted_labels = [labels[int(pred)] for pred in predictions]
+
+# Add the predicted labels to the dataframe and save
+df['predicted_label'] = predicted_labels
+df.to_csv("labeled_muckrock_dataset.csv", index=False)

--- a/muckrock-tools/search-local-foia-json.py
+++ b/muckrock-tools/search-local-foia-json.py
@@ -1,0 +1,38 @@
+import json
+
+# Specify the JSON file path
+json_file = 'foia_data.json'
+search_string = 'use of force'
+
+# Load the JSON data
+with open(json_file, 'r', encoding='utf-8') as file:
+    data = json.load(file)
+
+# List to store matching entries
+matching_entries = []
+
+# Function to search within an entry
+def search_entry(entry):
+    # Check if 'status' is 'done'
+    if entry.get('status') != 'done':
+        return False
+    
+    # Check if 'title' or 'tags' field contains the search string
+    title_match = 'title' in entry and search_string.lower() in entry['title'].lower()
+    tags_match = 'tags' in entry and any(search_string.lower() in tag.lower() for tag in entry['tags'])
+    
+    return title_match or tags_match
+
+# Iterate through the data and collect matching entries
+for entry in data:
+    if search_entry(entry):
+        matching_entries.append(entry)
+
+# Output the results
+print(f"Found {len(matching_entries)} entries containing '{search_string}' in the title or tags.")
+
+# Optionally, write matching entries to a new JSON file
+with open('matching_entries.json', 'w', encoding='utf-8') as file:
+    json.dump(matching_entries, file, indent=4)
+
+print(f"Matching entries written to 'matching_entries.json'")


### PR DESCRIPTION
Addresses [this issue](https://github.com/Police-Data-Accessibility-Project/data-projects/issues/8)

Below is the `README.md` for explanation of tools

# Muckrock Toolkit

## Description
This repo provides tools for searching Muckrock FOIA requests, it includes scripts for downloading data from MuckRock, generating CSV files per PDAP database requirements, and automatic labeling

## Uses

### 1. Simple Search Term
- `muck-get.py`
- script to perform searches on MuckRock's database, by matching a search string to title of request. Search is slow due to rate limiting (cannot multi thread around it).

### 2. Clone Muckrock database & search locally
- `download-muckrock-foia.py` `search-local-foia-json.py`
- scripts to clone the MuckRock repository for fast local querying (total size <2GB at present)

### 3. County Level Search
- `get-allegheny-foias.py`, `allegheny-county-towns.txt`
- To search for any and all requests in a certain county (e.g. Allegheny in this case) you must provide a list of all municipalities contained within the county. Muckrock stores geographic info in tiers, from Federal, State, and local level. At the local level, e.g. Pittsburgh and Allegheny County are in the same tier, with no way to determine which municipalities reside within a county (without providing it yourself).

The `get-allegheny-foias.py` script will find the jurisdiction ID for each municipality in `allegheny-county-towns.txt`, then find all completed FOIA requests for those jurisdictions.

### 4. Generate detailed FOIA data in PDAP database format 
- `generate-detailed-muckrock-csv.py`
- Once you have a json of relevant FOIA's, run it through this script to generate a CSV that fulfills PDAP database requirements.

### 5. ML Labeling 
- `muckrock-ml-labeler.py`
- A tool for auto labeling MuckRock sources. This script is using [fine-url-classifier](https://huggingface.co/PDAP/fine-url-classifier) to assign 1 of 36 record type labels. At present, script is expecting each source to have associated header tags, provided via `html-tag-collector/collector.py`. (TODO: For muckrock sources, `collector.py` insufficient, does not grab main text of the request) 